### PR TITLE
Remove user-info style

### DIFF
--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -1,14 +1,10 @@
-import ItemList from "./ItemList";
-import React from "react";
-import { Link } from "react-router-dom";
-import agent from "../agent";
-import { connect } from "react-redux";
-import {
-  FOLLOW_USER,
-  UNFOLLOW_USER,
-  PROFILE_PAGE_LOADED,
-  PROFILE_PAGE_UNLOADED,
-} from "../constants/actionTypes";
+import React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import agent from '../agent';
+import { FOLLOW_USER, PROFILE_PAGE_LOADED, PROFILE_PAGE_UNLOADED, UNFOLLOW_USER } from '../constants/actionTypes';
+import ItemList from './ItemList';
 
 const EditProfileSettings = (props) => {
   if (props.isUser) {
@@ -127,7 +123,7 @@ class Profile extends React.Component {
       <div className="profile-page">
         <div className="container">
           <div className="row p-4 text-center">
-            <div className="user-info col-xs-12 col-md-8 offset-md-2">
+            <div className="col-xs-12 col-md-8 offset-md-2">
               <img
                 src={profile.image}
                 className="user-img"

--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -1,10 +1,14 @@
-import React from 'react';
-import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
-
-import agent from '../agent';
-import { FOLLOW_USER, PROFILE_PAGE_LOADED, PROFILE_PAGE_UNLOADED, UNFOLLOW_USER } from '../constants/actionTypes';
-import ItemList from './ItemList';
+import ItemList from "./ItemList";
+import React from "react";
+import { Link } from "react-router-dom";
+import agent from "../agent";
+import { connect } from "react-redux";
+import {
+  FOLLOW_USER,
+  UNFOLLOW_USER,
+  PROFILE_PAGE_LOADED,
+  PROFILE_PAGE_UNLOADED,
+} from "../constants/actionTypes";
 
 const EditProfileSettings = (props) => {
   if (props.isUser) {

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION

# Description

Removes `user-info` style

Was causing Profile page to not look ok on mobile sizes

Before

<img width="379" alt="image" src="https://user-images.githubusercontent.com/71710839/183246300-904928cb-3412-41a2-bc4d-7e305c16c701.png">


After

<img width="352" alt="image" src="https://user-images.githubusercontent.com/71710839/183246293-5b9cda0c-2347-433b-b656-d2bbf18e2efb.png">